### PR TITLE
added current commit hash to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "web-encoding": "1.1.5"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "export REACT_APP_BUILD_COMMIT=$(git rev-parse HEAD) && react-scripts start",
+    "build": "export REACT_APP_BUILD_COMMIT=$(git rev-parse HEAD) && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "eb:prod": "npm run build && npm run start:prod",

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
     <link rel="manifest" href="/icons/site.webmanifest?v=1">
     <link rel="mask-icon" href="/icons/safari-pinned-tab.svg?v=1" color="#5bbad5">
     <link rel="shortcut icon" href="/icons/favicon.ico?v=1">
+    <meta name="build-commit" content="%REACT_APP_BUILD_COMMIT%">
     <meta name="msapplication-TileColor" content="#ffc40d">
     <meta name="msapplication-config" content="/icons/browserconfig.xml?v=1">
     <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
this pr adds the latest commit hash into the build. should be handy when it comes to debugging. no more asking manitcor what's currently deployed on production :-)

preview: https://teia-commit-hash.onrender.com/

<img width="615" alt="Bildschirmfoto 2022-02-24 um 17 01 23" src="https://user-images.githubusercontent.com/182512/155561456-62e0067d-f381-4c08-b345-d79c02781e8c.png">

