### PR TITLE
feat: 🚚 Store mint fields in local cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11525,21 +11525,6 @@
         "node": ">=8.12.0"
       }
     },
-    "node_modules/husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -33812,11 +33797,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
-    },
-    "husky": {
-      "version": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
-      "dev": true
     },
     "iconv-lite": {
       "version": "0.6.3",

--- a/src/pages/mint/index.js
+++ b/src/pages/mint/index.js
@@ -383,6 +383,24 @@ export const Mint = () => {
     `);
   }
 
+  const clearFields = () => {
+      setTitle('')
+      setDescription('')
+      setTags('')
+      setAmount('')
+      setRoyalties('')
+
+      const keys = [
+        "objkt::title",
+        "objkt::description",
+        "objkt::tags",
+        "objkt::edition_count",
+        "objkt::royalties",
+      ]
+
+      keys.forEach((k) => window.localStorage.removeItem(k));
+  }
+
   const hasStoredFields = () => {
     const title = window.localStorage.getItem('objkt::title')
     const description = window.localStorage.getItem('objkt::description')
@@ -494,6 +512,18 @@ export const Mint = () => {
                 label="Royalties"
                 value={royalties}
               />
+            </Padding>
+          </Container>
+
+          <Container>
+            <Padding>
+            <div style={{ display: 'flex', justifyContent: 'flex-end'}}>
+            <Button onClick={clearFields} fit>
+                  <Primary>
+                    Clear Fields
+                  </Primary>
+                </Button>
+                </div>
             </Padding>
           </Container>
 

--- a/src/pages/mint/index.js
+++ b/src/pages/mint/index.js
@@ -1,32 +1,23 @@
-import React, { useContext, useEffect, useState } from 'react'
+import classNames from 'classnames'
 import Compressor from 'compressorjs'
 import ipfsHash from 'ipfs-only-hash'
 import _ from 'lodash'
-import { HicetnuncContext } from '../../context/HicetnuncContext'
-import { Page, Container, Padding } from '../../components/layout'
-import { Input, Textarea } from '../../components/input'
-import { Button, Curate, Primary, Purchase } from '../../components/button'
-import { Upload } from '../../components/upload'
-import { Preview } from '../../components/preview'
-import { prepareFile, prepareDirectory } from '../../data/ipfs'
-import { prepareFilesFromZIP } from '../../utils/html'
-import {
-  ALLOWED_MIMETYPES,
-  ALLOWED_FILETYPES_LABEL,
-  ALLOWED_COVER_MIMETYPES,
-  ALLOWED_COVER_FILETYPES_LABEL,
-  MINT_FILESIZE,
-  MIMETYPE,
-  MAX_EDITIONS,
-  MIN_ROYALTIES,
-  MAX_ROYALTIES,
-  BURN_ADDRESS
-} from '../../constants'
-import { fetchGraphQL, getCollabsForAddress, getNameForAddress } from '../../data/hicdex'
-import collabStyles from '../../components/collab/styles.module.scss'
-import classNames from 'classnames'
-import { CollabContractsOverview } from '../collaborate/tabs/manage'
+import { useContext, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { Button, Curate, Primary, Purchase } from '../../components/button'
+import collabStyles from '../../components/collab/styles.module.scss'
+import { Input, Textarea } from '../../components/input'
+import { Container, Padding, Page } from '../../components/layout'
+import { Preview } from '../../components/preview'
+import { Upload } from '../../components/upload'
+import {
+  ALLOWED_COVER_FILETYPES_LABEL, ALLOWED_COVER_MIMETYPES, ALLOWED_FILETYPES_LABEL, ALLOWED_MIMETYPES, BURN_ADDRESS, MAX_EDITIONS, MAX_ROYALTIES, MIMETYPE, MINT_FILESIZE, MIN_ROYALTIES
+} from '../../constants'
+import { HicetnuncContext } from '../../context/HicetnuncContext'
+import { fetchGraphQL, getCollabsForAddress, getNameForAddress } from '../../data/hicdex'
+import { prepareDirectory, prepareFile } from '../../data/ipfs'
+import { prepareFilesFromZIP } from '../../utils/html'
+import { CollabContractsOverview } from '../collaborate/tabs/manage'
 
 const coverOptions = {
   quality: 0.85,
@@ -369,6 +360,40 @@ export const Mint = () => {
     return true
   }
 
+  const handleLocalCache = () => {
+    const title = window.localStorage.getItem('objkt::title')
+    const description = window.localStorage.getItem('objkt::description')
+    const tags = window.localStorage.getItem('objkt::tags')
+    const edition_count = window.localStorage.getItem('objkt::edition_count')
+    const royalties = window.localStorage.getItem('objkt::royalties')
+
+    setTitle(title)
+    setDescription(description)
+    setTags(tags)
+    setAmount(edition_count)
+    setRoyalties(royalties)
+
+    console.log(`
+    Restoring fields from localStorage:
+      title = ${title}
+      description = ${description}
+      tags = ${tags}
+      edition_count = ${edition_count}
+      royalties = ${royalties}
+
+    `);
+  }
+
+  const hasLocalCache = () => {
+    const title = window.localStorage.getItem('objkt::title')
+    const description = window.localStorage.getItem('objkt::description')
+    const tags = window.localStorage.getItem('objkt::tags')
+    const edition_count = window.localStorage.getItem('objkt::edition_count')
+    const royalties = window.localStorage.getItem('objkt::royalties')
+
+    return title != null || description != null || tags != null || edition_count != null || royalties != null
+  }
+
   // const proxyDisplay = proxyName || proxyAddress
   // const mintingAs = proxyDisplay || (acc?.name || acc?.address)
   const flexBetween = classNames(collabStyles.flex, collabStyles.flexBetween)
@@ -400,26 +425,38 @@ export const Mint = () => {
             <Padding>
               <Input
                 type="text"
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="Title"
-                label="Title"
+                onChange={(e) => {
+                  setTitle(e.target.value)
+                  window.localStorage.setItem('objkt::title', e.target.value)
+                  }
+                }
+                placeholder="title"
+                label="title"
                 value={title}
               />
 
               <Textarea
                 type="text"
                 style={{ whiteSpace: 'pre' }}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Description (max 5000 characters)"
-                label="Description"
+                onChange={(e) => {
+                  setDescription(e.target.value)
+                  window.localStorage.setItem('objkt::description', e.target.value)
+                  }
+                }
+                placeholder="description (max 5000 characters)"
+                label="description"
                 value={description}
               />
 
               <Input
                 type="text"
-                onChange={(e) => setTags(e.target.value)}
-                placeholder="Tags (comma separated. example: illustration, digital)"
-                label="Tags"
+                onChange={(e) => {
+                  setTags(e.target.value)
+                  window.localStorage.setItem('objkt::tags', e.target.value)
+                  }
+                }
+                placeholder="tags (comma separated. example: illustration, digital)"
+                label="tags"
                 value={tags}
               />
 
@@ -427,7 +464,11 @@ export const Mint = () => {
                 type="number"
                 min={1}
                 max={MAX_EDITIONS}
-                onChange={(e) => setAmount(e.target.value)}
+                onChange={(e) => {
+                  setAmount(e.target.value)
+                  window.localStorage.setItem('objkt::edition_count', e.target.value)
+                  }
+                }
                 onBlur={(e) => {
                   limitNumericField(e.target, 1, MAX_EDITIONS)
                   setAmount(e.target.value)
@@ -441,7 +482,11 @@ export const Mint = () => {
                 type="number"
                 min={MIN_ROYALTIES}
                 max={MAX_ROYALTIES}
-                onChange={(e) => setRoyalties(e.target.value)}
+                onChange={(e) => {
+                  setRoyalties(e.target.value)
+                  window.localStorage.setItem('objkt::royalties', e.target.value)
+                  }
+                }
                 onBlur={(e) => {
                   limitNumericField(e.target, MIN_ROYALTIES, MAX_ROYALTIES)
                   setRoyalties(e.target.value)
@@ -474,6 +519,16 @@ export const Mint = () => {
                 />
               </Padding>
             </Container>
+          )}
+          {hasLocalCache() && (
+          <Container>
+            <Padding>
+              {/*disabled={!hasCache()} */}
+              <Button onClick={handleLocalCache} fit  >
+                <Curate>Restore</Curate>
+              </Button>
+            </Padding>
+          </Container>
           )}
 
           <Container>

--- a/src/pages/mint/index.js
+++ b/src/pages/mint/index.js
@@ -231,7 +231,8 @@ export const Mint = () => {
         path: nftCid.path,
         royalties,
       })
-      mint(minterAddress, amount, nftCid.path, royalties)
+      await mint(minterAddress, amount, nftCid.path, royalties)
+      clearFields()
     }
   }
 

--- a/src/pages/mint/index.js
+++ b/src/pages/mint/index.js
@@ -1,23 +1,36 @@
-import classNames from 'classnames'
+import React, { useContext, useEffect, useState } from 'react'
 import Compressor from 'compressorjs'
 import ipfsHash from 'ipfs-only-hash'
 import _ from 'lodash'
-import { useContext, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { Button, Curate, Primary, Purchase } from '../../components/button'
-import collabStyles from '../../components/collab/styles.module.scss'
-import { Input, Textarea } from '../../components/input'
-import { Container, Padding, Page } from '../../components/layout'
-import { Preview } from '../../components/preview'
-import { Upload } from '../../components/upload'
-import {
-  ALLOWED_COVER_FILETYPES_LABEL, ALLOWED_COVER_MIMETYPES, ALLOWED_FILETYPES_LABEL, ALLOWED_MIMETYPES, BURN_ADDRESS, MAX_EDITIONS, MAX_ROYALTIES, MIMETYPE, MINT_FILESIZE, MIN_ROYALTIES
-} from '../../constants'
 import { HicetnuncContext } from '../../context/HicetnuncContext'
-import { fetchGraphQL, getCollabsForAddress, getNameForAddress } from '../../data/hicdex'
-import { prepareDirectory, prepareFile } from '../../data/ipfs'
+import { Page, Container, Padding } from '../../components/layout'
+import { Input, Textarea } from '../../components/input'
+import { Button, Curate, Primary, Purchase } from '../../components/button'
+import { Upload } from '../../components/upload'
+import { Preview } from '../../components/preview'
+import { prepareFile, prepareDirectory } from '../../data/ipfs'
 import { prepareFilesFromZIP } from '../../utils/html'
+import {
+  ALLOWED_MIMETYPES,
+  ALLOWED_FILETYPES_LABEL,
+  ALLOWED_COVER_MIMETYPES,
+  ALLOWED_COVER_FILETYPES_LABEL,
+  MINT_FILESIZE,
+  MIMETYPE,
+  MAX_EDITIONS,
+  MIN_ROYALTIES,
+  MAX_ROYALTIES,
+  BURN_ADDRESS,
+} from '../../constants'
+import {
+  fetchGraphQL,
+  getCollabsForAddress,
+  getNameForAddress,
+} from '../../data/hicdex'
+import collabStyles from '../../components/collab/styles.module.scss'
+import classNames from 'classnames'
 import { CollabContractsOverview } from '../collaborate/tabs/manage'
+import { Link } from 'react-router-dom'
 
 const coverOptions = {
   quality: 0.85,
@@ -44,7 +57,7 @@ const uriQuery = `query uriQuery($address: String!, $ids: [String!] = "") {
       }
     }
   }
-}`;
+}`
 
 // @crzypathwork change to "true" to activate displayUri and thumbnailUri
 const GENERATE_DISPLAY_AND_THUMBNAIL = true
@@ -67,7 +80,6 @@ export const Mint = () => {
   const [needsCover, setNeedsCover] = useState(false)
   const [collabs, setCollabs] = useState([])
   const [selectCollab, setSelectCollab] = useState(false)
-
 
   // On mount, see if there are available collab contracts
   useEffect(() => {
@@ -105,7 +117,6 @@ export const Mint = () => {
   }
 
   const handleMint = async () => {
-
     if (!acc) {
       // warning for sync
       setFeedback({
@@ -179,7 +190,7 @@ export const Mint = () => {
       // ztepler: I have not understand the difference between acc.address and getAuth here
       //    so I am using acc.address (minterAddress) in both nftCid.address and in mint call
 
-      console.log({minterAddress})
+      console.log({ minterAddress })
 
       // upload file(s)
       let nftCid
@@ -197,7 +208,7 @@ export const Mint = () => {
           cover,
           thumbnail,
           generateDisplayUri: GENERATE_DISPLAY_AND_THUMBNAIL,
-          file
+          file,
         })
       } else {
         // process all other files
@@ -214,21 +225,29 @@ export const Mint = () => {
         })
       }
 
-      console.log("Calling mint with", { minterAddress, amount, path: nftCid.path, royalties })
+      console.log('Calling mint with', {
+        minterAddress,
+        amount,
+        path: nftCid.path,
+        royalties,
+      })
       mint(minterAddress, amount, nftCid.path, royalties)
     }
   }
 
   const isDoubleMint = async () => {
     const rawLeaves = false
-    const hashv0 = await ipfsHash.of(file.buffer, { cidVersion:0, rawLeaves })
-    const hashv1 = await ipfsHash.of(file.buffer, { cidVersion:1, rawLeaves })
+    const hashv0 = await ipfsHash.of(file.buffer, { cidVersion: 0, rawLeaves })
+    const hashv1 = await ipfsHash.of(file.buffer, { cidVersion: 1, rawLeaves })
     console.log(`Current CIDv0: ${hashv0}`)
     console.log(`Current CIDv1: ${hashv1}`)
 
     const uri0 = `ipfs://${hashv0}`
     const uri1 = `ipfs://${hashv1}`
-    const { errors, data } = await fetchGraphQL(uriQuery, 'uriQuery',  {"address": proxyAddress || acc.address,"ids":[uri0, uri1]})
+    const { errors, data } = await fetchGraphQL(uriQuery, 'uriQuery', {
+      address: proxyAddress || acc.address,
+      ids: [uri0, uri1],
+    })
 
     if (errors) {
       setFeedback({
@@ -242,7 +261,10 @@ export const Mint = () => {
       })
       return true
     } else if (data) {
-      const areAllTokensBurned = (data.hic_et_nunc_token || []).every((token) => _.get(token, 'token_holders.0.holder.address') === BURN_ADDRESS);
+      const areAllTokensBurned = (data.hic_et_nunc_token || []).every(
+        (token) =>
+          _.get(token, 'token_holders.0.holder.address') === BURN_ADDRESS
+      )
 
       if (areAllTokensBurned) {
         return false
@@ -261,11 +283,11 @@ export const Mint = () => {
       return true
     }
 
-    return false;
+    return false
   }
 
   const handlePreview = async () => {
-    if (!await isDoubleMint()) {
+    if (!(await isDoubleMint())) {
       setStep(1)
     }
   }
@@ -380,25 +402,25 @@ export const Mint = () => {
       tags = ${tags}
       edition_count = ${edition_count}
       royalties = ${royalties}
-    `);
+    `)
   }
 
   const clearFields = () => {
-      setTitle('')
-      setDescription('')
-      setTags('')
-      setAmount('')
-      setRoyalties('')
+    setTitle('')
+    setDescription('')
+    setTags('')
+    setAmount('')
+    setRoyalties('')
 
-      const keys = [
-        "objkt::title",
-        "objkt::description",
-        "objkt::tags",
-        "objkt::edition_count",
-        "objkt::royalties",
-      ]
+    const keys = [
+      'objkt::title',
+      'objkt::description',
+      'objkt::tags',
+      'objkt::edition_count',
+      'objkt::royalties',
+    ]
 
-      keys.forEach((k) => window.localStorage.removeItem(k));
+    keys.forEach((k) => window.localStorage.removeItem(k))
   }
 
   const hasStoredFields = () => {
@@ -408,7 +430,13 @@ export const Mint = () => {
     const edition_count = window.localStorage.getItem('objkt::edition_count')
     const royalties = window.localStorage.getItem('objkt::royalties')
 
-    return title != null || description != null || tags != null || edition_count != null || royalties != null
+    return (
+      title != null ||
+      description != null ||
+      tags != null ||
+      edition_count != null ||
+      royalties != null
+    )
   }
 
   // const proxyDisplay = proxyName || proxyAddress
@@ -419,13 +447,14 @@ export const Mint = () => {
     <Page title="Mint" large>
       {step === 0 && (
         <>
-
           {/* User has collabs available */}
           {collabs.length > 0 && (
             <Container>
               <Padding>
                 <div className={flexBetween}>
-                  <p><span style={{ opacity: 0.5 }}>minting as</span> {mintName}</p>
+                  <p>
+                    <span style={{ opacity: 0.5 }}>minting as</span> {mintName}
+                  </p>
                   <Button onClick={() => setSelectCollab(!selectCollab)}>
                     <Purchase>{selectCollab ? 'Cancel' : 'Change'}</Purchase>
                   </Button>
@@ -434,9 +463,7 @@ export const Mint = () => {
             </Container>
           )}
 
-          {selectCollab && (
-            <CollabContractsOverview showAdminOnly={true} />
-          )}
+          {selectCollab && <CollabContractsOverview showAdminOnly={true} />}
 
           <Container>
             <Padding>
@@ -445,10 +472,9 @@ export const Mint = () => {
                 onChange={(e) => {
                   setTitle(e.target.value)
                   window.localStorage.setItem('objkt::title', e.target.value)
-                  }
-                }
+                }}
                 placeholder="title"
-                label="title"
+                label="Title"
                 value={title}
               />
 
@@ -457,11 +483,13 @@ export const Mint = () => {
                 style={{ whiteSpace: 'pre' }}
                 onChange={(e) => {
                   setDescription(e.target.value)
-                  window.localStorage.setItem('objkt::description', e.target.value)
-                  }
-                }
+                  window.localStorage.setItem(
+                    'objkt::description',
+                    e.target.value
+                  )
+                }}
                 placeholder="description (max 5000 characters)"
-                label="description"
+                label="Description"
                 value={description}
               />
 
@@ -470,10 +498,9 @@ export const Mint = () => {
                 onChange={(e) => {
                   setTags(e.target.value)
                   window.localStorage.setItem('objkt::tags', e.target.value)
-                  }
-                }
+                }}
                 placeholder="tags (comma separated. example: illustration, digital)"
-                label="tags"
+                label="Tags"
                 value={tags}
               />
 
@@ -483,9 +510,11 @@ export const Mint = () => {
                 max={MAX_EDITIONS}
                 onChange={(e) => {
                   setAmount(e.target.value)
-                  window.localStorage.setItem('objkt::edition_count', e.target.value)
-                  }
-                }
+                  window.localStorage.setItem(
+                    'objkt::edition_count',
+                    e.target.value
+                  )
+                }}
                 onBlur={(e) => {
                   limitNumericField(e.target, 1, MAX_EDITIONS)
                   setAmount(e.target.value)
@@ -501,9 +530,11 @@ export const Mint = () => {
                 max={MAX_ROYALTIES}
                 onChange={(e) => {
                   setRoyalties(e.target.value)
-                  window.localStorage.setItem('objkt::royalties', e.target.value)
-                  }
-                }
+                  window.localStorage.setItem(
+                    'objkt::royalties',
+                    e.target.value
+                  )
+                }}
                 onBlur={(e) => {
                   limitNumericField(e.target, MIN_ROYALTIES, MAX_ROYALTIES)
                   setRoyalties(e.target.value)
@@ -517,13 +548,11 @@ export const Mint = () => {
 
           <Container>
             <Padding>
-            <div style={{ display: 'flex', justifyContent: 'flex-end'}}>
-            <Button onClick={clearFields} fit>
-                  <Primary>
-                    Clear Fields
-                  </Primary>
+              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <Button onClick={clearFields} fit>
+                  <Primary>Clear Fields</Primary>
                 </Button>
-                </div>
+              </div>
             </Padding>
           </Container>
 
@@ -550,7 +579,6 @@ export const Mint = () => {
             </Container>
           )}
 
-
           <Container>
             <Padding>
               <Button onClick={handlePreview} fit disabled={handleValidation()}>
@@ -558,7 +586,6 @@ export const Mint = () => {
               </Button>
             </Padding>
           </Container>
-
         </>
       )}
 
@@ -607,9 +634,7 @@ export const Mint = () => {
 
       <Container>
         <Padding>
-          <Link to="/terms">
-            Terms & Conditions
-          </Link>
+          <Link to="/terms">Terms & Conditions</Link>
         </Padding>
       </Container>
       {/*       <BottomBanner>

--- a/src/pages/mint/index.js
+++ b/src/pages/mint/index.js
@@ -82,7 +82,7 @@ export const Mint = () => {
         setCollabs(managedCollabs || [])
       }
     })
-
+    if (hasStoredFields()) restoreFields()
     updateName()
   }, [acc]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -360,7 +360,7 @@ export const Mint = () => {
     return true
   }
 
-  const handleLocalCache = () => {
+  const restoreFields = () => {
     const title = window.localStorage.getItem('objkt::title')
     const description = window.localStorage.getItem('objkt::description')
     const tags = window.localStorage.getItem('objkt::tags')
@@ -380,11 +380,10 @@ export const Mint = () => {
       tags = ${tags}
       edition_count = ${edition_count}
       royalties = ${royalties}
-
     `);
   }
 
-  const hasLocalCache = () => {
+  const hasStoredFields = () => {
     const title = window.localStorage.getItem('objkt::title')
     const description = window.localStorage.getItem('objkt::description')
     const tags = window.localStorage.getItem('objkt::tags')
@@ -520,16 +519,7 @@ export const Mint = () => {
               </Padding>
             </Container>
           )}
-          {hasLocalCache() && (
-          <Container>
-            <Padding>
-              {/*disabled={!hasCache()} */}
-              <Button onClick={handleLocalCache} fit  >
-                <Curate>Restore</Curate>
-              </Button>
-            </Padding>
-          </Container>
-          )}
+
 
           <Container>
             <Padding>


### PR DESCRIPTION
This is useful for instance when a mint fails.
As noted by @xat this will weaken the current double mint detection
as users will be able to mint twice in a row faster.
Very much a WIP, just merging from the old repo

Adresses #4