### PR TITLE
use cross-env to set environment variables in npm scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "screenfull": "^5.1.0"
       },
       "devDependencies": {
+        "cross-env": "^7.0.3",
         "prettier": "^2.3.0"
       }
     },
@@ -6900,6 +6901,24 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -30165,6 +30184,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "screenfull": "^5.1.0"
   },
   "scripts": {
-    "start": "export REACT_APP_BUILD_COMMIT=$(git rev-parse HEAD) && react-scripts start",
-    "build": "export REACT_APP_BUILD_COMMIT=$(git rev-parse HEAD) && react-scripts build",
+    "start": "cross-env REACT_APP_BUILD_COMMIT=$(git rev-parse HEAD) react-scripts start",
+    "build": "cross-env REACT_APP_BUILD_COMMIT=$(git rev-parse HEAD) react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "prettier": "prettier --write \"./src/**/*.{js,jsx}\""
@@ -65,6 +65,7 @@
     ]
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "prettier": "^2.3.0"
   },
   "module": "commonjs"


### PR DESCRIPTION
this is supposed to solve the problem that the build fails on windows. i couldn't test it though, because i don't use windows.