### PR TITLE
fix: 🔥 git commit on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "screenfull": "^5.1.0"
   },
   "scripts": {
-    "start": "export REACT_APP_BUILD_COMMIT=$(git rev-parse HEAD) && react-scripts start",
-    "build": "export REACT_APP_BUILD_COMMIT=$(git rev-parse HEAD) && react-scripts build",
+    "start": "REACT_APP_BUILD_COMMIT=`git rev-parse HEAD` react-scripts start",
+    "build": "REACT_APP_BUILD_COMMIT=`git rev-parse HEAD` react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "prettier": "prettier --write \"./src/**/*.{js,jsx}\""


### PR DESCRIPTION
If we don't chain the commands export is not needed.